### PR TITLE
upgrade: upload des fichiers PPTX + dossiers img/ et resources/ dans artefact final

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -52,3 +52,7 @@ runs:
         path: |
           **/*.pdf
           **/*.html
+          **/*.pptx
+          img/
+          resources/
+          


### PR DESCRIPTION
Ajouter 3 lignes pour ajouter qq trucs dans l'artefact final, notament:

- les fichiers .pptx (parfois les kickoff sont seulement dans ce format, parfois dans les 2. Et parfois les pptx contiennent des contenus dynamiques du type vidéo, qui ne le sont pas dans les PDF)
- les dossiers img/ (qui contiennent les images du projet, pour la version HTML du sujet pour les mal-voyants)
- le dossier resources/ (qui contient des choses qui doivent finir sur l'intra/moodle, pour les students, et/ou pour les pédagos) Remqrque : ce dossier n'existe pas toujours dans les repos, ça peut ptet poser soucis sur certains repos s'il n'est pas trouvé)